### PR TITLE
Edge fix

### DIFF
--- a/src/createLoadableVisibilityComponent.js
+++ b/src/createLoadableVisibilityComponent.js
@@ -93,7 +93,7 @@ function createLoadableVisibilityComponent (args, {
 
       if (LoadingComponent) {
         return <div
-          style={{display: 'inline-block'}}
+          style={{display: 'inline-block', minHeight: '1px', minWidth: '1px'}}
           className={this.props.className}
           ref={this.attachRef}
         >
@@ -104,7 +104,7 @@ function createLoadableVisibilityComponent (args, {
       }
 
       return <div
-        style={{display: 'inline-block'}}
+        style={{display: 'inline-block', minHeight: '1px', minWidth: '1px'}}
         className={this.props.className}
         ref={this.attachRef}
       />


### PR DESCRIPTION
Hi,

Since a couple of months Edge supports the Intersection Observer which is of course great news. However the Intersection Observer implementation in Edge requires the target element to have a `height` and `width` of at least `1px` as discussed [here](https://stackoverflow.com/questions/45090875/ms-edge-intersectionobserver-does-it-work-for-you) on Stack Overflow.