### PR TITLE
Fix memory leak when using server-side

### DIFF
--- a/src/__mocks__/IntersectionObserver.js
+++ b/src/__mocks__/IntersectionObserver.js
@@ -1,4 +1,7 @@
 const intersectionObservers = []
+const trackedElements = []
+
+module.exports.trackedElements = trackedElements
 
 module.exports.makeElementsVisible = function makeElementsVisible () {
   intersectionObservers.forEach((observer) => {
@@ -17,7 +20,7 @@ module.exports.IntersectionObserver = class IntersectionObserver {
   constructor(callback) {
     this.callback = callback
 
-    this.trackedElements = []
+    this.trackedElements = trackedElements
 
     intersectionObservers.push(this)
   }

--- a/src/__mocks__/IntersectionObserver.js
+++ b/src/__mocks__/IntersectionObserver.js
@@ -1,7 +1,7 @@
 const intersectionObservers = []
-const trackedElements = []
+const globallyTrackedElements = []
 
-module.exports.trackedElements = trackedElements
+module.exports.globallyTrackedElements = globallyTrackedElements
 
 module.exports.makeElementsVisible = function makeElementsVisible () {
   intersectionObservers.forEach((observer) => {
@@ -20,13 +20,14 @@ module.exports.IntersectionObserver = class IntersectionObserver {
   constructor(callback) {
     this.callback = callback
 
-    this.trackedElements = trackedElements
+    this.trackedElements = []
 
     intersectionObservers.push(this)
   }
 
   observe(element) {
     this.trackedElements.push(element)
+    globallyTrackedElements.push(element)
   }
 
   unobserve(element) {
@@ -34,6 +35,12 @@ module.exports.IntersectionObserver = class IntersectionObserver {
 
     if (elementIndex >= 0) {
       this.trackedElements.splice(elementIndex, 1)
+    }
+
+    const globalIndex = globallyTrackedElements.indexOf(element)
+
+    if (globalIndex>= 0) {
+      globallyTrackedElements.splice(elementIndex, 1)
     }
   }
 }

--- a/src/__tests__/loadable-components/intersection-observer.test.js
+++ b/src/__tests__/loadable-components/intersection-observer.test.js
@@ -7,6 +7,7 @@ const { IntersectionObserver, makeElementsVisible } = require('../../__mocks__/I
 global.IntersectionObserver = IntersectionObserver
 
 const loadableVisiblity = require('../../loadable-components')
+const trackedElements = require('../../tracked_elements').default
 
 const opts = {
   loading: () => null,
@@ -17,6 +18,7 @@ const props = {'a': 1, 'b': 2}
 
 beforeEach(() => {
   jest.resetAllMocks()
+  trackedElements.clear()
 })
 
 describe('Loadable', () => {
@@ -40,6 +42,18 @@ describe('Loadable', () => {
     expect(loadable.loadableReturn).toHaveBeenCalledWith(props)
   })
 
+  test('it clears out tracked elements when they become visible', () => {
+    const Loader = loadableVisiblity(opts)
+
+    const wrapper = mount(<Loader {...props} />)
+
+    expect(trackedElements.size).toEqual(1)
+
+    makeElementsVisible()
+
+    expect(trackedElements.size).toEqual(0)
+  })
+
   test('preload calls loadable load', () => {
     loadableVisiblity(opts).load()
 
@@ -52,5 +66,15 @@ describe('Loadable', () => {
     const wrapper = mount(<Loader className='my-class-name' />)
 
     expect(wrapper.find('.my-class-name')).toHaveLength(1)
+  })
+
+  test('it does not set up visibility handlers until mounted', () => {
+    const Loader = loadableVisiblity(opts)
+
+    expect(trackedElements.size).toEqual(0)
+
+    const wrapper = mount(<Loader className='my-class-name' />)
+
+    expect(trackedElements.size).toEqual(1)
   })
 })

--- a/src/__tests__/loadable-components/intersection-observer.test.js
+++ b/src/__tests__/loadable-components/intersection-observer.test.js
@@ -2,12 +2,15 @@ const loadable = require('loadable-components')
 const React = require('react')
 const { mount } = require('enzyme')
 
-const { IntersectionObserver, makeElementsVisible } = require('../../__mocks__/IntersectionObserver')
+const {
+  IntersectionObserver,
+  makeElementsVisible,
+  trackedElements
+} = require('../../__mocks__/IntersectionObserver')
 
 global.IntersectionObserver = IntersectionObserver
 
 const loadableVisiblity = require('../../loadable-components')
-const trackedElements = require('../../tracked_elements').default
 
 const opts = {
   loading: () => null,
@@ -18,7 +21,7 @@ const props = {'a': 1, 'b': 2}
 
 beforeEach(() => {
   jest.resetAllMocks()
-  trackedElements.clear()
+  trackedElements.length = 0
 })
 
 describe('Loadable', () => {
@@ -47,11 +50,11 @@ describe('Loadable', () => {
 
     const wrapper = mount(<Loader {...props} />)
 
-    expect(trackedElements.size).toEqual(1)
+    expect(trackedElements.length).toEqual(1)
 
     makeElementsVisible()
 
-    expect(trackedElements.size).toEqual(0)
+    expect(trackedElements.length).toEqual(0)
   })
 
   test('preload calls loadable load', () => {
@@ -59,6 +62,30 @@ describe('Loadable', () => {
 
     expect(loadable().load).toHaveBeenCalled()
   })
+
+  test('preload will cause the loadable component do be displayed', () => {
+    const Loader = loadableVisiblity(opts)
+
+    const wrapper = mount(<Loader {...props} />)
+    expect(wrapper.find('loadableObject')).toHaveLength(0)
+
+    Loader.load();
+
+    expect(wrapper.find('loadableObject')).toHaveLength(1)
+  });
+
+  test('it displays the loadable component when it becomes visible', () => {
+    const Loader = loadableVisiblity(opts)
+
+    const wrapper = mount(<Loader {...props} className="loading-class-name" />)
+    expect(wrapper.find('.loading-class-name')).toHaveLength(1)
+    expect(wrapper.find('loadableObject')).toHaveLength(0)
+
+    makeElementsVisible()
+
+    expect(wrapper.find('.loading-class-name')).toHaveLength(0)
+    expect(wrapper.find('loadableObject')).toHaveLength(1)
+  });
 
   test('passes the className prop', () => {
     const Loader = loadableVisiblity(opts)
@@ -71,10 +98,10 @@ describe('Loadable', () => {
   test('it does not set up visibility handlers until mounted', () => {
     const Loader = loadableVisiblity(opts)
 
-    expect(trackedElements.size).toEqual(0)
+    expect(trackedElements.length).toEqual(0)
 
     const wrapper = mount(<Loader className='my-class-name' />)
 
-    expect(trackedElements.size).toEqual(1)
+    expect(trackedElements.length).toEqual(1)
   })
 })

--- a/src/__tests__/loadable-components/intersection-observer.test.js
+++ b/src/__tests__/loadable-components/intersection-observer.test.js
@@ -5,7 +5,7 @@ const { mount } = require('enzyme')
 const {
   IntersectionObserver,
   makeElementsVisible,
-  trackedElements
+  globallyTrackedElements
 } = require('../../__mocks__/IntersectionObserver')
 
 global.IntersectionObserver = IntersectionObserver
@@ -21,7 +21,7 @@ const props = {'a': 1, 'b': 2}
 
 beforeEach(() => {
   jest.resetAllMocks()
-  trackedElements.length = 0
+  globallyTrackedElements.length = 0
 })
 
 describe('Loadable', () => {
@@ -50,11 +50,11 @@ describe('Loadable', () => {
 
     const wrapper = mount(<Loader {...props} />)
 
-    expect(trackedElements.length).toEqual(1)
+    expect(globallyTrackedElements.length).toEqual(1)
 
     makeElementsVisible()
 
-    expect(trackedElements.length).toEqual(0)
+    expect(globallyTrackedElements.length).toEqual(0)
   })
 
   test('preload calls loadable load', () => {
@@ -63,7 +63,7 @@ describe('Loadable', () => {
     expect(loadable().load).toHaveBeenCalled()
   })
 
-  test('preload will cause the loadable component do be displayed', () => {
+  test('preload will cause the loadable component to be displayed', () => {
     const Loader = loadableVisiblity(opts)
 
     const wrapper = mount(<Loader {...props} />)
@@ -98,10 +98,10 @@ describe('Loadable', () => {
   test('it does not set up visibility handlers until mounted', () => {
     const Loader = loadableVisiblity(opts)
 
-    expect(trackedElements.length).toEqual(0)
+    expect(globallyTrackedElements.length).toEqual(0)
 
     const wrapper = mount(<Loader className='my-class-name' />)
 
-    expect(trackedElements.length).toEqual(1)
+    expect(globallyTrackedElements.length).toEqual(1)
   })
 })

--- a/src/__tests__/react-loadable/intersection-observer.test.js
+++ b/src/__tests__/react-loadable/intersection-observer.test.js
@@ -53,6 +53,30 @@ describe('Loadable', () => {
 
     expect(wrapper.find('.my-class-name')).toHaveLength(1)
   })
+
+  test('preload will cause the loadable component to be displayed', () => {
+    const Loader = LoadableVisibility(opts)
+
+    const wrapper = mount(<Loader {...props} />)
+    expect(wrapper.find('LoadableObject')).toHaveLength(0)
+
+    Loader.preload();
+
+    expect(wrapper.find('LoadableObject')).toHaveLength(1)
+  });
+
+  test('it displays the loadable component when it becomes visible', () => {
+    const Loader = LoadableVisibility(opts)
+
+    const wrapper = mount(<Loader {...props} className="loading-class-name" />)
+    expect(wrapper.find('.loading-class-name')).toHaveLength(1)
+    expect(wrapper.find('LoadableObject')).toHaveLength(0)
+
+    makeElementsVisible()
+
+    expect(wrapper.find('.loading-class-name')).toHaveLength(0)
+    expect(wrapper.find('LoadableObject')).toHaveLength(1)
+  });
 })
 
 describe('Loadable.Map', () => {

--- a/src/tracked_elements.js
+++ b/src/tracked_elements.js
@@ -1,0 +1,1 @@
+export default new Map()

--- a/src/tracked_elements.js
+++ b/src/tracked_elements.js
@@ -1,1 +1,0 @@
-export default new Map()


### PR DESCRIPTION
I recently ran into a memory leak when using this server-side. This occurs because the visibility handlers are set up in the constructor instead of a lifecycle hook, and because `componentWillUnmount` does not execute server-side, we never stop observing the element. I set up a simple example of this happening here: https://github.com/the83/memory-leak-example

This moves the setup into the `componentDidMount` hook so that we don't even observe visibility at all server-side.

