### PR TITLE
#18 Add `isIntersecting` attribute fallback for zero threshold

### DIFF
--- a/src/__mocks__/IntersectionObserver.js
+++ b/src/__mocks__/IntersectionObserver.js
@@ -1,13 +1,27 @@
 const intersectionObservers = []
 const globallyTrackedElements = []
+const elementVisibilityStates = {
+  byIntersecting: {
+    isIntersecting: true,
+    intersectionRatio: 0,
+  },
+  byRatio: {
+    isIntersecting: undefined,
+    intersectionRatio: 0.1,
+  }
+}
 
 module.exports.globallyTrackedElements = globallyTrackedElements
 
-module.exports.makeElementsVisible = function makeElementsVisible () {
+/**
+ * @param {'byIntersecting' | 'byRatio'} mode
+ */
+module.exports.makeElementsVisible = function makeElementsVisible (mode = 'byRatio') {
+  const intersectionObject = elementVisibilityStates[mode];
   intersectionObservers.forEach((observer) => {
     const entries = observer.trackedElements.map((element) => {
       return {
-        intersectionRatio: 1,
+        ...intersectionObject,
         target: element,
       }
     })
@@ -39,7 +53,7 @@ module.exports.IntersectionObserver = class IntersectionObserver {
 
     const globalIndex = globallyTrackedElements.indexOf(element)
 
-    if (globalIndex>= 0) {
+    if (globalIndex >= 0) {
       globallyTrackedElements.splice(elementIndex, 1)
     }
   }

--- a/src/__tests__/loadable-components/intersection-observer.test.js
+++ b/src/__tests__/loadable-components/intersection-observer.test.js
@@ -40,8 +40,18 @@ describe('Loadable', () => {
 
     expect(loadable.loadableReturn).not.toHaveBeenCalled()
 
-    makeElementsVisible()
+    makeElementsVisible('byRatio')
+    expect(loadable.loadableReturn).toHaveBeenCalledWith(props)
+  })
 
+  test('calls "loadable" when intersectionRatio equals 0 but isIntersecting is true', () => {
+    const Loader = loadableVisiblity(opts)
+
+    const wrapper = mount(<Loader {...props} />)
+
+    expect(loadable.loadableReturn).not.toHaveBeenCalled()
+
+    makeElementsVisible('byIntersecting')
     expect(loadable.loadableReturn).toHaveBeenCalledWith(props)
   })
 

--- a/src/__tests__/react-loadable/intersection-observer.test.js
+++ b/src/__tests__/react-loadable/intersection-observer.test.js
@@ -35,8 +35,18 @@ describe('Loadable', () => {
 
     expect(Loadable.LoadableReturn).not.toHaveBeenCalled()
 
-    makeElementsVisible()
+    makeElementsVisible('byRatio')
+    expect(Loadable.LoadableReturn).toHaveBeenCalledWith(props)
+  })
 
+  test('calls "loadable" when intersectionRatio equals 0 but isIntersecting is true', () => {
+    const Loader = LoadableVisibility(opts)
+
+    const wrapper = mount(<Loader {...props} />)
+
+    expect(Loadable.LoadableReturn).not.toHaveBeenCalled()
+
+    makeElementsVisible('byIntersecting')
     expect(Loadable.LoadableReturn).toHaveBeenCalledWith(props)
   })
 

--- a/src/createLoadableVisibilityComponent.js
+++ b/src/createLoadableVisibilityComponent.js
@@ -9,7 +9,10 @@ if (IntersectionObserver) {
     entries.forEach((entry) => {
       const trackedElement = trackedElements.get(entry.target)
 
-      if (trackedElement && entry.intersectionRatio > 0) {
+      if (
+        trackedElement &&
+        (entry.isIntersecting || entry.intersectionRatio > 0)
+      ) {
         trackedElement.visibilityHandler()
       }
     })


### PR DESCRIPTION
We can't just use `entry.intersectionRatio >= 0` because it will lead to false positives, instead, we can add `isIntersecting` attribute as a second conditional.

To be honest, there is a chance that using **only** `isIntersecting` would be enough.