### PR TITLE
Don't spread props onto DOM elements, fixes #35

### DIFF
--- a/src/createLoadableVisibilityComponent.js
+++ b/src/createLoadableVisibilityComponent.js
@@ -77,7 +77,6 @@ function createLoadableVisibilityComponent(
             minHeight: "1px",
             minWidth: "1px"
           }}
-          {...props}
           ref={visibilityElementRef}
         >
           {LoadingComponent
@@ -93,7 +92,6 @@ function createLoadableVisibilityComponent(
     return (
       <div
         style={{ display: "inline-block", minHeight: "1px", minWidth: "1px" }}
-        {...props}
         ref={visibilityElementRef}
       />
     );


### PR DESCRIPTION
Currently all props are being spread onto the wrapping `div` elements, this is causing react to complain about unknown props on DOM elements. I can't see an obvious reason for the spread given that props intended for the lazy-loaded component should not need to be present on a wrapper element. So, this PR removes the spreads entirely.

cc. @tazsingh 